### PR TITLE
doc: fix javadoc

### DIFF
--- a/src/main/java/it/astromark/authentication/service/AuthenticationService.java
+++ b/src/main/java/it/astromark/authentication/service/AuthenticationService.java
@@ -114,7 +114,7 @@ public interface AuthenticationService {
     /**
      * Retrieves the parent details if the user is a parent.
      *
-     * @return an `Optional<Parent>` containing the parent details if available
+     * @return an `Optional Parent containing the parent details if available
      * Pre-condition: The user must be logged in and identified as a parent.
      * Post-condition: Returns an optional containing the parent details or empty if not applicable.
      */
@@ -123,7 +123,7 @@ public interface AuthenticationService {
     /**
      * Retrieves the student details if the user is a student.
      *
-     * @return an `Optional<Student>` containing the student details if available
+     * @return an `Optional Student` containing the student details if available
      * Pre-condition: The user must be logged in and identified as a student.
      * Post-condition: Returns an optional containing the student details or empty if not applicable.
      */
@@ -132,7 +132,7 @@ public interface AuthenticationService {
     /**
      * Retrieves the teacher details if the user is a teacher.
      *
-     * @return an `Optional<Teacher>` containing the teacher details if available
+     * @return an `Optional Teacher` containing the teacher details if available
      * Pre-condition: The user must be logged in and identified as a teacher.
      * Post-condition: Returns an optional containing the teacher details or empty if not applicable.
      */
@@ -141,7 +141,7 @@ public interface AuthenticationService {
     /**
      * Retrieves the secretary details if the user is a secretary.
      *
-     * @return an `Optional<Secretary>` containing the secretary details if available
+     * @return an `Optional Secretary` containing the secretary details if available
      * Pre-condition: The user must be logged in and identified as a secretary.
      * Post-condition: Returns an optional containing the secretary details or empty if not applicable.
      */

--- a/src/main/java/it/astromark/classmanagement/service/ClassManagementService.java
+++ b/src/main/java/it/astromark/classmanagement/service/ClassManagementService.java
@@ -102,7 +102,7 @@ public interface ClassManagementService {
     /**
      * Removes a class associated with a specific teacher.
      *
-     * @param teacheruuid   the UUID of the teacher whose class is to be removed
+     * @param uuuid   the UUID of the teacher whose class is to be removed
      * @param schoolClassId the ID of the class to be removed
      *                      Pre-condition: The `teacheruuid` and `schoolClassId` must not be null. The teacher and class must exist.
      *                      Post-condition: The specified class is removed from the teacher's assignments.


### PR DESCRIPTION
This pull request includes changes to the `AuthenticationService` and `ClassManagementService` interfaces to correct parameter names and improve the documentation format. The most important changes include fixing the format of return types in several methods and correcting a parameter name in a method.

Documentation improvements in `AuthenticationService`:

* Corrected the format of the return type for the `getParentDetails` method to `Optional Parent`.
* Corrected the format of the return type for the `getStudentDetails` method to `Optional Student`.
* Corrected the format of the return type for the `getTeacherDetails` method to `Optional Teacher`.
* Corrected the format of the return type for the `getSecretaryDetails` method to `Optional Secretary`.

Parameter name correction in `ClassManagementService`:

* Changed the parameter name from `teacheruuid` to `uuuid` in the `removeClass` method.