### PR TITLE
ci: fix deploy

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -18,4 +18,5 @@ jobs:
           javadoc-branch: javadoc
           java-version: 21
           target-folder: javadoc
+          javadoc-source-folder: target/report/apidocs
           project: maven


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish-javadoc.yml` file. The change adds a new configuration parameter to specify the source folder for Javadoc generation.

* [`.github/workflows/publish-javadoc.yml`](diffhunk://#diff-f11713a91d52980b8445e22cde0ba2734d54e92e59d673c690156e5d6e77b410R21): Added `javadoc-source-folder` parameter to specify the source folder for Javadoc generation.